### PR TITLE
require 'fileutils.rb'

### DIFF
--- a/vendor/plugins/cached_externals/recipes/cached_externals.rb
+++ b/vendor/plugins/cached_externals/recipes/cached_externals.rb
@@ -37,6 +37,7 @@ namespace :externals do
   DESC
   task :setup, :except => { :no_release => true } do
     require 'capistrano/recipes/deploy/scm'
+    require 'fileutils.rb'
 
     external_modules.each do |path, options|
       puts "configuring #{path}"
@@ -72,3 +73,4 @@ end
 # fail and leaving some assets temporally out of sync, potentially, with
 # the other servers.
 before "deploy:finalize_update", "externals:setup"
+


### PR DESCRIPTION
Not a capistrano expert (or a Ruby expert, for that matter) but was getting a NameError on the command "cap local externals:setup" in this file.  Added the require, it fixed it.  Ruby was trying to find FileUtils in the Capistrano namespace.
