### PR TITLE
Pass CSRF token in event creation.

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,7 +8,7 @@ class EventsController < ApplicationController
   def index
     respond_to do |format|
       format.js do
-        json = events.to_json(eager_options(:root => "events", :include => { :tagged_items => { :only => [:amount, :id], :methods => :name }, :line_items => { :only => [:account_id, :bucket_id, :amount, :role], :methods => [] }}))
+        json = events.to_json(eager_options(:root => "event", :include => { :tagged_items => { :only => [:amount, :id], :methods => :name }, :line_items => { :only => [:account_id, :bucket_id, :amount, :role], :methods => [] }}))
 
         render :update do |page|
           page << "Events.doneLoadingRecalledEvents(#{json})"

--- a/public/javascripts/events.js
+++ b/public/javascripts/events.js
@@ -469,6 +469,9 @@ var Events = {
 
       options.method = "post";
       options.contentType = "application/xml";
+      options.requestHeaders = {
+        'X-CSRF-Token': $F(form['authenticity_token'])
+      };
       options.postBody = Events.buildXMLStringFor(Events.serialize(form));
 
       return new Ajax.Request(action, options);


### PR DESCRIPTION
I noticed that the session was getting smashed whenever I tried to create an event and eventually discovered that Rails 2.3.11 now considers this action to be CSRF-protected and needs the authenticity token.
